### PR TITLE
Domain uri is url encoded and Server uri (from workspace) is not

### DIFF
--- a/VsExt.AutoShelve/TfsAutoShelve.cs
+++ b/VsExt.AutoShelve/TfsAutoShelve.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Threading;
+using System.Web;
 using EnvDTE80;
 using Microsoft.TeamFoundation.Client;
 using Microsoft.TeamFoundation.VersionControl.Client;
@@ -156,7 +157,8 @@ namespace VsExt.AutoShelve {
         public void SaveShelveset() {
             try {
                 if (TfsExt == null) return;
-                var domainUri = _tfsExt.ActiveProjectContext.DomainUri;
+                // decode the url: some repo's have spaces in them, which are url encoded to %20.
+                var domainUri = HttpUtility.UrlDecode(_tfsExt.ActiveProjectContext.DomainUri);
                 var teamProjectCollection = TfsTeamProjectCollectionFactory.GetTeamProjectCollection(new Uri(domainUri));
                 teamProjectCollection.Credentials = CredentialCache.DefaultNetworkCredentials;
                 teamProjectCollection.EnsureAuthenticated();

--- a/VsExt.AutoShelve/TfsAutoShelve.cs
+++ b/VsExt.AutoShelve/TfsAutoShelve.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Threading;
-using System.Web;
 using EnvDTE80;
 using Microsoft.TeamFoundation.Client;
 using Microsoft.TeamFoundation.VersionControl.Client;

--- a/VsExt.AutoShelve/TfsAutoShelve.cs
+++ b/VsExt.AutoShelve/TfsAutoShelve.cs
@@ -158,7 +158,7 @@ namespace VsExt.AutoShelve {
             try {
                 if (TfsExt == null) return;
                 // decode the url: some repo's have spaces in them, which are url encoded to %20.
-                var domainUri = HttpUtility.UrlDecode(_tfsExt.ActiveProjectContext.DomainUri);
+                var domainUri = WebUtility.UrlDecode(_tfsExt.ActiveProjectContext.DomainUri);
                 var teamProjectCollection = TfsTeamProjectCollectionFactory.GetTeamProjectCollection(new Uri(domainUri));
                 teamProjectCollection.Credentials = CredentialCache.DefaultNetworkCredentials;
                 teamProjectCollection.EnsureAuthenticated();

--- a/VsExt.AutoShelve/VsExt.AutoShelve.csproj
+++ b/VsExt.AutoShelve/VsExt.AutoShelve.csproj
@@ -86,6 +86,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>

--- a/VsExt.AutoShelve/VsExt.AutoShelve.csproj
+++ b/VsExt.AutoShelve/VsExt.AutoShelve.csproj
@@ -86,7 +86,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
DomainUri is url encoded and needs te be decoded before being matched with the workspace ServerUri.

e.g. "http://some.tfs.domain/Main%20Collection" does not match "http://some.tfs.domain/Main Collection"

Before this change, no shelveset would be created when the DomainUri contained characters that are affected by the UrlEncode method. Resulting in no shelveset and no information for the end user why no shelves are created. I only fixed the first problem by UrlDecoding the DomainUri.