### PR TITLE
Changed date format to sortable and culture invariant yyyy-mm-ddThh:mm:ss

### DIFF
--- a/VsExt.AutoShelve/Properties/AssemblyInfo.cs
+++ b/VsExt.AutoShelve/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("6.2.0.0")]
-[assembly: AssemblyFileVersion("6.2.0.0")]
+[assembly: AssemblyVersion("6.2.1.0")]
+[assembly: AssemblyFileVersion("6.2.1.0")]
 
 [assembly: InternalsVisibleTo("VsExt.AutoShelve_IntegrationTests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004384bdada0d14bf775ac485ec80645ad481714418b8a6fbc2d336e96bcd57dd0e7f980239d8fe5eccd4088a1d042ac1c7a482ef1415e40b2787152d2669a9407416f71961323bf5ed4ec30012dc18e0185ce623d35ec47a54f9c591a54e13ab71bd3a10b339cd4ebc4bc7977bd6103f953da37aff8d1436d56ee173c2e5782e6")]
 [assembly: InternalsVisibleTo("VsExt.AutoShelve_UnitTests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004384bdada0d14bf775ac485ec80645ad481714418b8a6fbc2d336e96bcd57dd0e7f980239d8fe5eccd4088a1d042ac1c7a482ef1415e40b2787152d2669a9407416f71961323bf5ed4ec30012dc18e0185ce623d35ec47a54f9c591a54e13ab71bd3a10b339cd4ebc4bc7977bd6103f953da37aff8d1436d56ee173c2e5782e6")]

--- a/VsExt.AutoShelve/TfsAutoShelve.cs
+++ b/VsExt.AutoShelve/TfsAutoShelve.cs
@@ -206,7 +206,7 @@ namespace VsExt.AutoShelve
                         autoShelveEventArg.ShelvesetChangeCount = numPending;
 
                         // Build a new, valid shelve set name
-                        var setname = string.Format(ShelvesetName, workspace.Name, workspace.OwnerName, DateTime.Now, workspace.OwnerName.GetDomain(), workspace.OwnerName.GetLogin());
+                        var setname = string.Format(ShelvesetName, workspace.Name, workspace.OwnerName, DateTime.Now.ToString("s"), workspace.OwnerName.GetDomain(), workspace.OwnerName.GetLogin());
                         setname = CleanShelvesetName(setname);
 
                         // Actually create a new Shelveset 


### PR DESCRIPTION
Before you have used DateTime.Now.ToString()  which produced not sortable strings formatted with current user settings. They are harder to read and visually sort. (especially after removing all separators)
This commit makes date part to appear in constant sortable format regardless to current locale settings.

P.S. I was unable to compile and test the change, but it looks pretty harmless.